### PR TITLE
Closes #22: More standard conversions

### DIFF
--- a/src/enums/direction.rs
+++ b/src/enums/direction.rs
@@ -22,7 +22,7 @@ pub enum Direction {
 /// ```
 /// use hex_math::Direction;
 ///
-/// let direction: Direction = From::from(0);
+/// let direction: Direction = Direction::from(0);
 /// assert_eq!(direction, Direction::East);
 /// ```
 ///
@@ -30,7 +30,7 @@ pub enum Direction {
 /// use hex_math::Direction;
 ///
 /// for i in 0..6 {
-///   let direction: Direction = From::from(i);
+///   let direction: Direction = Direction::from(i);
 /// }
 /// ```
 impl From<i32> for Direction {

--- a/src/line.rs
+++ b/src/line.rs
@@ -264,7 +264,7 @@ mod util {
     let mut set: HashSet<Point> = HashSet::new();
 
     if point.values() == other.values() {
-      set.insert(Point::from_values(point.values()));
+      set.insert(point.to_point());
 
       return set;
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -53,22 +53,6 @@ impl Point {
     Point::new(q, r, 0)
   }
 
-  /// Convenience function for making points from a values tuple
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// use hex_math::{Point, HasValues};
-  ///
-  /// let point: Point = Point::new(1, 2, 5);
-  /// let other: Point = Point::from_values(point.values());
-  ///
-  /// assert_eq!((1, 2, 5), other.values());
-  /// ```
-  pub fn from_values((q, r, t): (i32, i32, i32)) -> Point {
-    Point::new(q, r, t)
-  }
-
 }
 
 /// Add one point to another
@@ -147,7 +131,7 @@ impl HasValues for Point {
 /// use hex_math::{Point, HasValues};
 ///
 /// let point: Point = Point::new(1, 2, 5);
-/// let other: Point = From::from(point.values());
+/// let other: Point = Point::from(point.values());
 ///
 /// assert_eq!((1, 2, 5), other.values());
 /// ```

--- a/src/traits/has_values.rs
+++ b/src/traits/has_values.rs
@@ -90,7 +90,7 @@ pub trait HasValues {
   /// assert_eq!((1, 2, 5), other.values());
   /// ```
   fn to_point(&self) -> Point {
-    Point::from_values(self.values())
+    Point::from(self.values())
   }
 
 }


### PR DESCRIPTION
Use Struct::From() instead of From::From() or unnecessary custom Struct::from_something().
