### PR TITLE
Closes #41: Make ray aware of walls

### DIFF
--- a/src/enums/direction.rs
+++ b/src/enums/direction.rs
@@ -37,5 +37,29 @@ impl Direction {
     ]
   }
 
-}
+  /// Return the opposite direction
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// use hex_math::Direction;
+  ///
+  /// let east: Direction = Direction::East;
+  ///
+  /// assert_eq!(Direction::West, east.opposite());
+  pub fn opposite(&self) -> Direction {
 
+    match self {
+      &Direction::East      => Direction::West,
+      &Direction::Southeast => Direction::Northwest,
+      &Direction::Southwest => Direction::Northeast,
+      &Direction::West      => Direction::East,
+      &Direction::Northwest => Direction::Southeast,
+      &Direction::Northeast => Direction::Southwest,
+      &Direction::Up        => Direction::Down,
+      &Direction::Down      => Direction::Up,
+    }
+
+  }
+
+}

--- a/src/structs/prism.rs
+++ b/src/structs/prism.rs
@@ -92,6 +92,27 @@ impl HasWalls for Prism {
 
 }
 
+/// Convert from a point to a prism with zero walls
+///
+/// # Example
+///
+/// ```
+/// use hex_math::{Point, Prism, HasValues, HasWalls};
+///
+/// let point: Point = Point::new(1, 2, 5);
+/// let prism: Prism = Prism::from(&point);
+///
+/// assert_eq!((1, 2, 5), prism.values());
+/// assert_eq!((0, 0, 0, 0), prism.walls());
+/// ```
+impl<'a> From<&'a Point> for Prism {
+
+  fn from(point: &'a Point) -> Prism {
+    Prism::new(Point::from(point.values()), 0, 0, 0, 0)
+  }
+
+}
+
 /// Convert from tuples of values and wall strengths
 ///
 /// # Example

--- a/src/traits/has_walls.rs
+++ b/src/traits/has_walls.rs
@@ -1,3 +1,4 @@
+use enums::Direction;
 use traits::HasValues;
 
 /// Provide access to a prism's walls
@@ -12,5 +13,37 @@ pub trait HasWalls: HasValues {
   /// by consistently using the same directions because one prism's west is
   /// another prism's east.
   fn walls(&self) -> (i32, i32, i32, i32);
+
+  /// Return whether there is a wall in the provided direction
+  ///
+  /// If the direction is not one of the four directions, false will always
+  /// be returned.
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// use hex_math::{Direction, Point, Prism, HasWalls};
+  ///
+  /// let point: Point = Point::new(1, 2, 5);
+  /// let prism: Prism = Prism::new(point, 1, 0, 0, 0);
+  ///
+  /// assert_eq!(true, prism.has_wall(&Direction::East));
+  /// assert_eq!(false, prism.has_wall(&Direction::Southeast));
+  /// ```
+  fn has_wall(&self, direction: &Direction) -> bool {
+
+    let (e, se, sw, d) = self.walls();
+
+    let result: bool = match direction {
+      &Direction::East => e > 0,
+      &Direction::Southeast => se > 0,
+      &Direction::Southwest => sw > 0,
+      &Direction::Down => d > 0,
+      _ => false,
+    };
+
+    result
+
+  }
 
 }


### PR DESCRIPTION
TLDR:
- Break before stepping from previous step to current step if a wall
  would prevent taking that step

Details:
- util::line takes a map(point, prism) instead of a set of opaque points
- Added util::get_step_direction(point, point), calculate step direction
  based on sign difference between previous step and current step values
- Added Direction::opposite(self), return direction opposite to self
- Convert from point to prism with no walls
- Return whether a HasWalls has wall in a provided direction
- Removed duplicated line/ray tests with 2d functions
