### PR TITLE
Issue #78: Implemented Predicate to extract logic

### DIFF
--- a/src/line/mod.rs
+++ b/src/line/mod.rs
@@ -1,3 +1,5 @@
+pub mod predicate;
+
 mod generic;
 mod of;
 mod ray;

--- a/src/line/of.rs
+++ b/src/line/of.rs
@@ -1,12 +1,14 @@
 use std::borrow::Borrow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use distance;
 use line;
-use structs::{Point, Prism};
+use line::predicate::Range;
+use structs::Point;
 
 /// Find the points in a line between the current point and the one provided
 pub fn of<T: Borrow<Point>>(point: &T, other: &T) -> HashSet<Point> {
-  line::generic(point, other, None, None::<&HashMap<Point, Prism>>)
+  line::generic(point, other, Range(distance::with_height(point, other)))
 }
 
 #[cfg(test)]

--- a/src/line/predicate/mod.rs
+++ b/src/line/predicate/mod.rs
@@ -1,0 +1,5 @@
+mod range;
+mod walls;
+
+pub use self::range::Range;
+pub use self::walls::Walls;

--- a/src/line/predicate/range.rs
+++ b/src/line/predicate/range.rs
@@ -1,0 +1,33 @@
+use structs::Point;
+use traits::Predicate;
+
+/// Stop the line if the index is out of range
+#[derive(Debug)]
+pub struct Range(pub i32);
+
+impl Predicate<(i32, Point, Point)> for Range {
+  fn apply(&self, args: &(i32, Point, Point)) -> bool {
+    let &Range(range) = self;
+    let &(index, _, _) = args;
+
+    index >= range
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const POINT: &'static Point = &Point(1, 2, 5);
+  const OTHER: &'static Point = &Point(3, 4, 10);
+
+  #[test]
+  fn apply_greater() {
+    assert!(Range(5).apply(&(6, *POINT, *OTHER)));
+  }
+
+  #[test]
+  fn apply_lesser() {
+    assert!(!Range(5).apply(&(4, *POINT, *OTHER)));
+  }
+}

--- a/src/line/predicate/walls.rs
+++ b/src/line/predicate/walls.rs
@@ -1,0 +1,48 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+
+use structs::{Point, Prism};
+use traits::{IsPointMap, Predicate};
+
+/// Stops the line if it hits a wall
+#[derive(Debug)]
+pub struct Walls<'a, T: Borrow<Prism>>(pub &'a HashMap<Point, T>) where T: 'a;
+
+impl <'a, T> Predicate<(i32, Point, Point)> for Walls<'a, T>
+  where T: Borrow<Prism> {
+
+  fn apply(&self, args: &(i32, Point, Point)) -> bool {
+    let &Walls(walls) = self;
+    let &(_, current, next) = args;
+
+    walls.has_wall_between(&current, &next)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use enums::Direction;
+  use travel::travel;
+
+  const POINT: &'static Point = &Point(1, 2, 5);
+
+  #[test]
+  fn apply_with_wall() {
+    let east = travel(&POINT, &Direction::East, 1);
+    let prism = Prism(*POINT, 1, 0, 0, 0);
+
+    let mut walls = HashMap::new();
+
+    walls.insert_walled_point(prism);
+
+    assert!(Walls(&walls).apply(&(0, *POINT, east)));
+  }
+
+  #[test]
+  fn apply_without_wall() {
+    let walls: HashMap<Point, Prism> = HashMap::new();
+
+    assert!(!Walls(&walls).apply(&(0, Point(1, 2, 5), *POINT)));
+  }
+}

--- a/src/line/ray.rs
+++ b/src/line/ray.rs
@@ -1,16 +1,22 @@
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 
+use distance;
 use line;
+use line::predicate::{Range, Walls};
 use structs::{Point, Prism};
 
 /// Find unblocked points in a line between two points
 pub fn ray<T: Borrow<Point>, U: Borrow<Prism>>(
   point: &T,
   other: &T,
-  map: &HashMap<Point, U>,
+  walls: &HashMap<Point, U>,
 ) -> HashSet<Point> {
-  line::generic(point, other, None, Some(map))
+  line::generic(
+    point,
+    other,
+    (Walls(walls), Range(distance::with_height(point, other)))
+  )
 }
 
 #[cfg(test)]

--- a/src/line/ray_through.rs
+++ b/src/line/ray_through.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 
 use line;
+use line::predicate::{Range, Walls};
 use structs::{Point, Prism};
 
 /// Find unblocked points within range in a line through two points
@@ -9,9 +10,9 @@ pub fn ray_through<T: Borrow<Point>, U: Borrow<Prism>>(
   point: &T,
   other: &T,
   range: i32,
-  map: &HashMap<Point, U>,
+  walls: &HashMap<Point, U>,
 ) -> HashSet<Point> {
-  line::generic(point, other, Some(range), Some(map))
+  line::generic(point, other, (Walls(walls), Range(range)))
 }
 
 #[cfg(test)]

--- a/src/line/through.rs
+++ b/src/line/through.rs
@@ -1,8 +1,9 @@
 use std::borrow::Borrow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use line;
-use structs::{Point, Prism};
+use line::predicate::Range;
+use structs::Point;
 
 /// Find the points within range in a line through two points
 pub fn through<T: Borrow<Point>>(
@@ -10,7 +11,7 @@ pub fn through<T: Borrow<Point>>(
   other: &T,
   range: i32,
 ) -> HashSet<Point> {
-  line::generic(point, other, Some(range), None::<&HashMap<Point, Prism>>)
+  line::generic(point, other, Range(range))
 }
 
 #[cfg(test)]

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,3 +1,5 @@
 mod is_point_map;
+mod predicate;
 
 pub use self::is_point_map::IsPointMap;
+pub use self::predicate::Predicate;

--- a/src/traits/predicate.rs
+++ b/src/traits/predicate.rs
@@ -1,0 +1,80 @@
+/// Report if a condition is true
+pub trait Predicate<T> {
+
+  /// Apply the predicate to determine if it passed or failed
+  fn apply(&self, args: &T) -> bool;
+}
+
+impl <T, U: Predicate<T>> Predicate<T> for Option<U> {
+  /// Unwrap an optional predicate and apply him or else return false
+  fn apply(&self, args: &T) -> bool {
+    match self {
+      &Some(ref predicate) => predicate.apply(args),
+      &None => false
+    }
+  }
+}
+
+impl <T, U, V> Predicate<T> for (U, V)
+  where U: Predicate<T>, V: Predicate<T> {
+
+  /// Apply both predicates and return true if either passes
+  fn apply(&self, args: &T) -> bool {
+    let &(ref first, ref second) = self;
+
+    first.apply(args) || second.apply(args)
+  }
+}
+
+impl <T> Predicate<T> for bool {
+
+  /// Always return the constant value.
+  fn apply(&self, _: &T) -> bool {
+    *self
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn apply_some() {
+    assert!(Some(true).apply(&()));
+  }
+
+  #[test]
+  fn apply_none() {
+    assert!(!None::<bool>.apply(&()));
+  }
+
+  #[test]
+  fn apply_tuple_yes_no() {
+    assert!((true, false).apply(&()));
+  }
+
+  #[test]
+  fn apply_tuple_yes_yes() {
+    assert!((true, true).apply(&()));
+  }
+
+  #[test]
+  fn apply_tuple_no_yes() {
+    assert!((false, true).apply(&()));
+  }
+
+  #[test]
+  fn apply_tuple_no_no() {
+    assert!(!(false, false).apply(&()));
+  }
+
+  #[test]
+  fn apply_true() {
+    assert!(true.apply(&()));
+  }
+
+  #[test]
+  fn apply_false() {
+    assert!(!false.apply(&()));
+  }
+}


### PR DESCRIPTION
There. Now the generic line function doesn't handle details like range or walls.

He can accept an arbitrary amount of conditions by creating a nested tuple Predicate: `(pred, (pred, (pred, pred)))`. Maybe I'd implement more tuple-to-predicate conversions if I was using that, but we don't have variadics in Rust, so nested tuples might be the lesser of two evils.

The point is that he could even be used with more predicates in the future (like wall strength) without adding any more code, and I've done this while shrinking the function body.

That's a refactor success imo. 